### PR TITLE
Remove no longer required hack

### DIFF
--- a/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml.cs
+++ b/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml.cs
@@ -30,18 +30,5 @@ namespace MessageBox.Avalonia.Views
         {
             AvaloniaXamlLoader.Load(this);
         }
-
-        protected override void OnOpened(EventArgs e)
-        {
-            base.OnOpened(e);
-
-            // Hack to fix scroll bar and limits
-            if (SizeToContent != SizeToContent.Manual)
-            {
-                SizeToContent = SizeToContent.Manual;
-                Width--;
-                Height--;
-            }
-        }
     }
 }


### PR DESCRIPTION
With the last Avalonia version this hack is no longer needed and can do more harm than good.
https://github.com/AvaloniaCommunity/MessageBox.Avalonia/issues/108