### PR TITLE
Long and screen constained ms

### DIFF
--- a/src/MessageBox.Avalonia.Example/MainWindow.xaml
+++ b/src/MessageBox.Avalonia.Example/MainWindow.xaml
@@ -17,6 +17,7 @@
   </Window.Styles>
   <StackPanel>
     <Button Name="btnClick" Click="MsBoxStandard_Click" Content="Standard"/>
+    <Button Name="btnClick7" Click="MsBoxStandardConstrained_Click" Content="Constrain to screen"/>
     <Button Name="btnClick2" Click="MsBoxCustom_Click" Content="Custom"/>
     <Button Name="btnClick5" Click="MsBoxCustomImage_Click" Content="Custom With Image"/>
     <Button Name="btnClick6" Click="MsBoxMarkdown_Click" Content="Markdown"/>

--- a/src/MessageBox.Avalonia.Example/MainWindow.xaml.cs
+++ b/src/MessageBox.Avalonia.Example/MainWindow.xaml.cs
@@ -42,9 +42,6 @@ namespace MessageBox.Avalonia.Example
 
         public async void MsBoxStandardConstrained_Click(object sender, RoutedEventArgs e)
         {
-
-
-
             int maxWidth = 500;
             int maxHeight = 800;
 

--- a/src/MessageBox.Avalonia.Example/MainWindow.xaml.cs
+++ b/src/MessageBox.Avalonia.Example/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
 using MessageBox.Avalonia.DTO;
 using MessageBox.Avalonia.Models;
+using System.Linq;
 using MessageBoxAvaloniaEnums = MessageBox.Avalonia.Enums;
 
 namespace MessageBox.Avalonia.Example
@@ -35,6 +36,43 @@ namespace MessageBox.Avalonia.Example
 
             var messageBoxStandardWindow = MessageBox.Avalonia.MessageBoxManager
                 .GetMessageBoxStandardWindow("Caption", "Are you sure you would like to delete appender_replace_page_1?", MessageBoxAvaloniaEnums.ButtonEnum.YesNo, MessageBoxAvaloniaEnums.Icon.None);
+
+            await messageBoxStandardWindow.ShowDialog(this);
+        }
+
+        public async void MsBoxStandardConstrained_Click(object sender, RoutedEventArgs e)
+        {
+
+
+
+            int maxWidth = 500;
+            int maxHeight = 800;
+
+            // If you want to auto strict the max sizes
+            var screen = Screens?.ScreenFromVisual(this);
+            if (screen is not null)
+            {
+                maxWidth = (int) (screen.WorkingArea.Width / screen.PixelDensity - 100);
+                maxHeight = (int) (screen.WorkingArea.Height / screen.PixelDensity - 50);
+            }
+
+            var messageBoxStandardWindow = MessageBox.Avalonia.MessageBoxManager.GetMessageBoxStandardWindow(
+                new MessageBoxStandardParams
+                {
+                    ButtonDefinitions = MessageBoxAvaloniaEnums.ButtonEnum.Ok,
+                    ContentTitle = "title",
+                    //ContentHeader = header,
+                    ContentMessage = "Informative note:\n\n" + 
+                                     string.Concat(Enumerable.Repeat("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ut pulvinar est, eget porttitor magna. Maecenas nunc elit, pretium nec mauris vel, cursus faucibus leo. Mauris consequat magna vel mi malesuada semper. Donec nunc justo, rhoncus vel viverra a, ultrices vel nibh. Praesent ut libero a nunc placerat vulputate. Morbi ullamcorper pharetra lectus, ut lobortis ex consequat sit amet. Vestibulum pellentesque quam at justo hendrerit, et tincidunt nisl mattis. Curabitur eu nibh enim.\n", 50)),
+                    Icon = MessageBoxAvaloniaEnums.Icon.Question,
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                    CanResize = false,
+                    MaxWidth = maxWidth,
+                    MaxHeight = maxHeight,
+                    SizeToContent = SizeToContent.WidthAndHeight,
+                    ShowInCenter = true,
+                    Topmost = false
+                });
 
             await messageBoxStandardWindow.ShowDialog(this);
         }

--- a/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml
@@ -72,9 +72,7 @@
             <Setter Property="MinHeight" Value="24" />
             <Setter Property="MinWidth" Value="75" />
         </Style>
-        <Style Selector="TextBox.contentMessage">
-            <Setter Property="Height" Value="50" />
-        </Style>
+
     </Window.Styles>
     <Grid Classes="MsBoxStandardContainer"   >
         <Grid.ColumnDefinitions>

--- a/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml.cs
+++ b/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml.cs
@@ -30,18 +30,5 @@ namespace MessageBox.Avalonia.Views
         {
             AvaloniaXamlLoader.Load(this);
         }
-
-        protected override void OnOpened(EventArgs e)
-        {
-            base.OnOpened(e);
-
-            // Hack to fix scroll bar and limits
-            if (SizeToContent != SizeToContent.Manual)
-            {
-                SizeToContent = SizeToContent.Manual;
-                Width--;
-                Height--;
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR adds a long and screen constained message box to example set.

However also shows a bug where line breaks make vertical size to not grow. Resizing the window have no effect on the visibility.
Bug:
![image](https://user-images.githubusercontent.com/113281/185680823-1f27c1a9-5077-44a7-8ed2-c29a93be93d5.png)

The bug may not come from Avalonia but rather anything set on styles or other, because on my own made control i'm able to get the proper outcome using same text:

![UVtools_2022-08-19_19-19-28](https://user-images.githubusercontent.com/113281/185682663-20f12b08-84ef-421b-95b5-82c04c0d1fe2.png)

**Edit:**

I was able to find the problem.
On style you got this:

```xml
        <Style Selector="TextBox.contentMessage">
            <Setter Property="Height" Value="50" />
        </Style>
```

constaining the message to be 50px. Maybe a forgotten leftover? 
It now produces the expected outcome:

![MessageBox Avalonia Example_2022-08-19_19-31-53](https://user-images.githubusercontent.com/113281/185684353-9f574ff5-fcd3-4859-ae2b-b05e9590dcc1.png)
