### PR TITLE
Upgrade Avalonia to 11.0.0-preview2

### DIFF
--- a/MessageBox.Avalonia.sln
+++ b/MessageBox.Avalonia.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29806.167
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.32916.344
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageBox.Avalonia", "src\MessageBox.Avalonia\MessageBox.Avalonia.csproj", "{C9CB33EA-26AC-4839-A754-E5B4F207B8BF}"
 EndProject

--- a/src/MessageBox.Avalonia.Example/MessageBox.Avalonia.Example.csproj
+++ b/src/MessageBox.Avalonia.Example/MessageBox.Avalonia.Example.csproj
@@ -13,9 +13,9 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview1" />
-	<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview1" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview1" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview2" />
+	<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview2" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MessageBox.Avalonia\MessageBox.Avalonia.csproj" />

--- a/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
+++ b/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
@@ -26,8 +26,8 @@
         </AvaloniaResource>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-preview1" />
-        <PackageReference Include="Markdown.Avalonia" Version="11.0.0-a1" />
+        <PackageReference Include="Avalonia" Version="11.0.0-preview2" />
+        <PackageReference Include="Markdown.Avalonia" Version="11.0.0-a3" />
     </ItemGroup>
     <ItemGroup>
         <UpToDateCheckInput Remove="Styles\Dark\Dark.xaml" />

--- a/src/MessageBox.Avalonia/ViewModels/MsBoxCustomViewModel.cs
+++ b/src/MessageBox.Avalonia/ViewModels/MsBoxCustomViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using MessageBox.Avalonia.DTO;
 using MessageBox.Avalonia.Models;
+using MessageBox.Avalonia.ViewModels.Commands;
 using MessageBox.Avalonia.Views;
 
 namespace MessageBox.Avalonia.ViewModels
@@ -14,9 +15,11 @@ namespace MessageBox.Avalonia.ViewModels
         {
             _window = msBoxCustomWindow;
             ButtonDefinitions = @params.ButtonDefinitions;
+            ButtonClickCommand = new RelayCommand(o => ButtonClick(o.ToString()));
         }
 
         public IEnumerable<ButtonDefinition> ButtonDefinitions { get; }
+        public RelayCommand ButtonClickCommand { get; }
 
         public void ButtonClick(string parameter)
         {

--- a/src/MessageBox.Avalonia/ViewModels/MsBoxHyperlinkViewModel.cs
+++ b/src/MessageBox.Avalonia/ViewModels/MsBoxHyperlinkViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using MessageBox.Avalonia.DTO;
 using MessageBox.Avalonia.Enums;
 using MessageBox.Avalonia.Models;
+using MessageBox.Avalonia.ViewModels.Commands;
 using MessageBox.Avalonia.Views;
 
 namespace MessageBox.Avalonia.ViewModels
@@ -17,6 +18,7 @@ namespace MessageBox.Avalonia.ViewModels
             _window = msBoxHyperlinkWindow;
             HyperlinkContentProvider = @params.HyperlinkContentProvider;
             SetButtons(@params.ButtonDefinitions);
+            ButtonClickCommand = new RelayCommand(o => ButtonClick(o.ToString()));
         }
 
         public bool IsOkShowed { get; private set; }
@@ -26,6 +28,7 @@ namespace MessageBox.Avalonia.ViewModels
         public bool IsCancelShowed { get; private set; }
 
         public IEnumerable<HyperlinkContent> HyperlinkContentProvider { get; set; }
+        public RelayCommand ButtonClickCommand { get; }
 
         private void SetButtons(ButtonEnum paramsButtonDefinitions)
         {

--- a/src/MessageBox.Avalonia/ViewModels/MsBoxInputViewModel.cs
+++ b/src/MessageBox.Avalonia/ViewModels/MsBoxInputViewModel.cs
@@ -7,6 +7,7 @@ using Avalonia.Interactivity;
 using MessageBox.Avalonia.DTO;
 using MessageBox.Avalonia.Enums;
 using MessageBox.Avalonia.Models;
+using MessageBox.Avalonia.ViewModels.Commands;
 using MessageBox.Avalonia.Views;
 
 namespace MessageBox.Avalonia.ViewModels
@@ -28,6 +29,7 @@ namespace MessageBox.Avalonia.ViewModels
             WatermarkText = @params.WatermarkText;
             Multiline = @params.Multiline;
             InputText = @params.InputDefaultValue;
+            ButtonClickCommand = new RelayCommand(o => ButtonClick(o.ToString()));
 
             // Make sure there are default buttons on dialog
             if (ButtonDefinitions is null)
@@ -112,6 +114,7 @@ namespace MessageBox.Avalonia.ViewModels
         // public ReactiveCommand<string, Unit> ButtonClickCommand { get; private set; }
 
         public IEnumerable<ButtonDefinition> ButtonDefinitions { get; }
+        public RelayCommand ButtonClickCommand { get; }
 
         public string InputText
         {

--- a/src/MessageBox.Avalonia/Views/MsBoxCustomWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxCustomWindow.xaml
@@ -113,7 +113,7 @@
                             Classes.default = "{Binding IsDefault}"
                             Classes.cancel = "{Binding IsCancel}"
                             Tag="{Binding TypeName}"
-                            Command="{Binding DataContext.ButtonClick, RelativeSource={RelativeSource AncestorType=Window, AncestorLevel=1}}"
+                            Command="{Binding DataContext.ButtonClickCommand, RelativeSource={RelativeSource AncestorType=Window, AncestorLevel=1}}"
                             CommandParameter="{Binding #Btn.Content}"
                             Content="{Binding Name}"
                             Margin="0 0 5 0"

--- a/src/MessageBox.Avalonia/Views/MsBoxHyperlinkWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxHyperlinkWindow.xaml
@@ -91,15 +91,15 @@
         <!--Buttons-->
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3"
                     HorizontalAlignment="Right">
-            <Button Content="Ok" Tag="Colored" Command="{Binding ButtonClick}"
+            <Button Content="Ok" Tag="Colored" Command="{Binding ButtonClickCommand}"
                     CommandParameter="{Binding $self.Content}" IsVisible="{Binding IsOkShowed}" />
-            <Button Content="Yes" Command="{Binding ButtonClick}" CommandParameter="{Binding $self.Content}"
+            <Button Content="Yes" Command="{Binding ButtonClickCommand}" CommandParameter="{Binding $self.Content}"
                     IsVisible="{Binding IsYesShowed}" />
-            <Button Content="No" Command="{Binding ButtonClick}" CommandParameter="{Binding $self.Content}"
+            <Button Content="No" Command="{Binding ButtonClickCommand}" CommandParameter="{Binding $self.Content}"
                     IsVisible="{Binding IsNoShowed}" />
-            <Button Content="Abort" Command="{Binding ButtonClick}" CommandParameter="{Binding $self.Content}"
+            <Button Content="Abort" Command="{Binding ButtonClickCommand}" CommandParameter="{Binding $self.Content}"
                     IsVisible="{Binding IsAbortShowed}" />
-            <Button Content="Cancel" Command="{Binding ButtonClick}" CommandParameter="{Binding $self.Content}"
+            <Button Content="Cancel" Command="{Binding ButtonClickCommand}" CommandParameter="{Binding $self.Content}"
                     IsVisible="{Binding IsCancelShowed}" />
         </StackPanel>
     </Grid>

--- a/src/MessageBox.Avalonia/Views/MsBoxInputWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxInputWindow.xaml
@@ -168,7 +168,7 @@
                 <DataTemplate>
                     <Button Name="Btn"
                             Tag="{Binding TypeName}"
-                            Command="{Binding DataContext.ButtonClick, RelativeSource={RelativeSource AncestorType=Window, AncestorLevel=1}}"
+                            Command="{Binding DataContext.ButtonClickCommand, RelativeSource={RelativeSource AncestorType=Window, AncestorLevel=1}}"
                             CommandParameter="{Binding #Btn.Content}"
                             Content="{Binding Name}"
                             Margin="0 0 5 0"


### PR DESCRIPTION
Also used RelayCommand `ButtonClickCommand` for button click in non-standard window types. Without this the buttons are disabled in Avalonia 11.0.0-preview2.
![image](https://user-images.githubusercontent.com/29546927/194724510-0a48d337-873c-4475-b16f-b810a6ee455d.png)

After the change they work correctly again.
![image](https://user-images.githubusercontent.com/29546927/194724758-ddaa9ba8-bcc4-40b2-9ec4-939570242838.png)
![image](https://user-images.githubusercontent.com/29546927/194724773-feb1950c-4c1e-4bf0-b457-cb0e9b141298.png)
![image](https://user-images.githubusercontent.com/29546927/194724823-340d29b8-92a5-4813-b512-7434a8861bab.png)
