### PR TITLE
Update for Avalonia 11.0.0-preview6

### DIFF
--- a/src/MessageBox.Avalonia.Example/MessageBox.Avalonia.Example.csproj
+++ b/src/MessageBox.Avalonia.Example/MessageBox.Avalonia.Example.csproj
@@ -13,9 +13,9 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview5" />
-	<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview5" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview5" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
+	<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MessageBox.Avalonia\MessageBox.Avalonia.csproj" />

--- a/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
+++ b/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
@@ -26,7 +26,7 @@
         </AvaloniaResource>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-preview5" />
+        <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
         <PackageReference Include="Markdown.Avalonia" Version="11.0.0-a9" />
     </ItemGroup>
     <ItemGroup>

--- a/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
+++ b/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
-        <PackageReference Include="Markdown.Avalonia" Version="11.0.0-a9" />
+        <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.0-a10" />
     </ItemGroup>
     <ItemGroup>
         <UpToDateCheckInput Remove="Styles\Dark\Dark.xaml" />

--- a/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
+++ b/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
-        <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.0-a10" />
+        <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.0-b1" />
     </ItemGroup>
     <ItemGroup>
         <UpToDateCheckInput Remove="Styles\Dark\Dark.xaml" />


### PR DESCRIPTION
- Bump to Avalonia 11.0.0-preview6
- Use latest preview version Markdown.Avalonia.Tight instead of Markdown.Avalonia package, because we don't need the syntax highlighting functionality: https://www.nuget.org/packages/Markdown.Avalonia.Tight#readme-tab

closes #129 

Now it works without throwing an exception:
![obraz](https://user-images.githubusercontent.com/29546927/227733355-748137c7-1911-42a7-9934-21794c61a903.png)
