### PR TITLE
Upgrade to Avalonia 11.0.0-preview7

### DIFF
--- a/src/MessageBox.Avalonia.Example/MessageBox.Avalonia.Example.csproj
+++ b/src/MessageBox.Avalonia.Example/MessageBox.Avalonia.Example.csproj
@@ -13,9 +13,9 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
-	<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview7" />
+	<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MessageBox.Avalonia\MessageBox.Avalonia.csproj" />

--- a/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
+++ b/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
@@ -26,7 +26,7 @@
         </AvaloniaResource>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
+        <PackageReference Include="Avalonia" Version="11.0.0-preview7" />
         <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.0-b1" />
     </ItemGroup>
     <ItemGroup>

--- a/src/MessageBox.Avalonia/Views/MsBoxCustomWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxCustomWindow.xaml
@@ -92,7 +92,7 @@
 
         </Grid>
         <!--Buttons-->
-        <ItemsControl Name="ButtonItemsPresenter" Classes="buttons-item-presenter" Items="{Binding ButtonDefinitions}" Grid.Row="3"
+        <ItemsControl Name="ButtonItemsPresenter" Classes="buttons-item-presenter" ItemsSource="{Binding ButtonDefinitions}" Grid.Row="3"
                         Grid.Column="1" Grid.ColumnSpan="3"
                         HorizontalAlignment="Right">
             <ItemsControl.ItemsPanel>

--- a/src/MessageBox.Avalonia/Views/MsBoxHyperlinkWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxHyperlinkWindow.xaml
@@ -74,7 +74,7 @@
             <TextBox Grid.Row="0" Classes="header" FontFamily="{Binding FontFamily}" Text="{Binding ContentHeader}"
                      IsVisible="{Binding HasHeader}" />
             <!--Content text-->
-            <ItemsControl x:Name="myItems" Items="{Binding HyperlinkContentProvider}">
+            <ItemsControl x:Name="myItems" ItemsSource="{Binding HyperlinkContentProvider}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <StackPanel Orientation="Horizontal" />

--- a/src/MessageBox.Avalonia/Views/MsBoxInputWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxInputWindow.xaml
@@ -155,7 +155,7 @@
 
         </Grid>
         <!--Buttons-->
-        <ItemsControl Items="{Binding ButtonDefinitions}" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3"
+        <ItemsControl ItemsSource="{Binding ButtonDefinitions}" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3"
                         HorizontalAlignment="Right">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>


### PR DESCRIPTION
Pretty self explanatory.

Preview7 now has Items read only and they want you to switch to `ItemsSource` as Items is now a read only view of `ItemsSource`.

This is outlined in their breaking change document here (the bottom text of the section): https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes#itemscontrol-changes-including-all-itemscontrol-inherited-controls-like-listbox-or-menus