### PR TITLE
Fix binding parent for custom buttons

### DIFF
--- a/MsBox.Avalonia/Controls/MsBoxCustomView.axaml
+++ b/MsBox.Avalonia/Controls/MsBoxCustomView.axaml
@@ -103,7 +103,7 @@
                             Classes.buttons="true"
                             Classes.default="{Binding IsDefault}"
                             Classes.cancel="{Binding IsCancel}"
-                            Command="{Binding ((viewModels:MsBoxCustomViewModel)DataContext).ButtonClickCommand, RelativeSource={RelativeSource AncestorType=Window, AncestorLevel=1}}"
+                            Command="{Binding ((viewModels:MsBoxCustomViewModel)DataContext).ButtonClickCommand, RelativeSource={RelativeSource AncestorType=UserControl, AncestorLevel=1}}"
                             CommandParameter="{Binding #Btn.Content}"
                             Content="{Binding Name}"
                             Margin="0 0 5 0"

--- a/MsBox.Avalonia/Controls/MsBoxCustomView.axaml.cs
+++ b/MsBox.Avalonia/Controls/MsBoxCustomView.axaml.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Threading.Tasks;
-using Avalonia;
+
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+
 using MsBox.Avalonia.Base;
 
 namespace MsBox.Avalonia.Controls;
@@ -14,12 +14,6 @@ public partial class MsBoxCustomView : UserControl, IFullApi<string>, ISetCloseA
     public MsBoxCustomView()
     {
         InitializeComponent();
-    }
-
-    
-    private void InitializeComponent()
-    {
-        AvaloniaXamlLoader.Load(this);
     }
 
     public void SetButtonResult(string bdName)

--- a/MsBox.Avalonia/Controls/MsBoxStandardView.axaml.cs
+++ b/MsBox.Avalonia/Controls/MsBoxStandardView.axaml.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Threading.Tasks;
-using Avalonia;
+
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+
 using MsBox.Avalonia.Base;
 using MsBox.Avalonia.Enums;
 
@@ -15,11 +15,6 @@ public partial class MsBoxStandardView : UserControl, IFullApi<ButtonResult>, IS
     public MsBoxStandardView()
     {
         InitializeComponent();
-    }
-
-    private void InitializeComponent()
-    {
-        AvaloniaXamlLoader.Load(this);
     }
 
     public void SetButtonResult(ButtonResult bdName)

--- a/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
+++ b/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
@@ -1,7 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Media;
 
-namespace MessageBox.Avalonia.DTO;
+namespace MsBox.Avalonia.Dto;
 
 public abstract class AbstractMessageBoxParams
 {

--- a/MsBox.Avalonia/Dto/MessageBoxCustomParams.cs
+++ b/MsBox.Avalonia/Dto/MessageBoxCustomParams.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Avalonia.Media.Imaging;
-using MessageBox.Avalonia.DTO;
-using MessageBox.Avalonia.Models;
+using MsBox.Avalonia.Models;
 using MsBox.Avalonia.Enums;
 
 namespace MsBox.Avalonia.Dto;

--- a/MsBox.Avalonia/Dto/MessageBoxStandardParams.cs
+++ b/MsBox.Avalonia/Dto/MessageBoxStandardParams.cs
@@ -1,7 +1,6 @@
-using MessageBox.Avalonia.Enums;
 using MsBox.Avalonia.Enums;
 
-namespace MessageBox.Avalonia.DTO;
+namespace MsBox.Avalonia.Dto;
 
 public class MessageBoxStandardParams : AbstractMessageBoxParams
 {

--- a/MsBox.Avalonia/Enums/ButtonEnum.cs
+++ b/MsBox.Avalonia/Enums/ButtonEnum.cs
@@ -1,4 +1,4 @@
-namespace MessageBox.Avalonia.Enums;
+namespace MsBox.Avalonia.Enums;
 
 /// <summary>
 /// Buttons in message box window

--- a/MsBox.Avalonia/MessageBoxManager.cs
+++ b/MsBox.Avalonia/MessageBoxManager.cs
@@ -1,6 +1,4 @@
 using Avalonia.Controls;
-using MessageBox.Avalonia.DTO;
-using MessageBox.Avalonia.Enums;
 using MsBox.Avalonia.Base;
 using MsBox.Avalonia.Controls;
 using MsBox.Avalonia.Dto;

--- a/MsBox.Avalonia/MessageBoxManager.cs
+++ b/MsBox.Avalonia/MessageBoxManager.cs
@@ -7,7 +7,7 @@ using MsBox.Avalonia.ViewModels;
 
 namespace MsBox.Avalonia;
 
-public class MessageBoxManager
+public static class MessageBoxManager
 {
     public static IMsBox<string> GetMessageBoxCustom(MessageBoxCustomParams @params)
     {

--- a/MsBox.Avalonia/Models/ButtonDefinition.cs
+++ b/MsBox.Avalonia/Models/ButtonDefinition.cs
@@ -1,4 +1,4 @@
-namespace MessageBox.Avalonia.Models;
+namespace MsBox.Avalonia.Models;
 
 public class ButtonDefinition
 {

--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -24,12 +24,9 @@
             <SubType>Designer</SubType>
         </AvaloniaResource>
         <AvaloniaResource Include="Assets\*" />
-        <AvaloniaResource Update="Views\MsBoxInputWindow.xaml">
-            <SubType>Designer</SubType>
-        </AvaloniaResource>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-rc2.2" />
+        <PackageReference Include="Avalonia" Version="11.0.0" />
         <PackageReference Include="DialogHost.Avalonia" Version="0.7.5" />
         <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.0-d1" />
     </ItemGroup>

--- a/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
@@ -6,8 +6,8 @@ using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using MessageBox.Avalonia.DTO;
 using MsBox.Avalonia.Base;
+using MsBox.Avalonia.Dto;
 using MsBox.Avalonia.Enums;
 
 namespace MsBox.Avalonia.ViewModels;

--- a/MsBox.Avalonia/ViewModels/MsBoxCustomViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/MsBoxCustomViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
-using MessageBox.Avalonia.Models;
 using MsBox.Avalonia.Base;
 using MsBox.Avalonia.Dto;
+using MsBox.Avalonia.Models;
 using MsBox.Avalonia.ViewModels.Commands;
 
 namespace MsBox.Avalonia.ViewModels;

--- a/MsBox.Avalonia/ViewModels/MsBoxStandardViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/MsBoxStandardViewModel.cs
@@ -1,8 +1,7 @@
 using System;
 using Avalonia.Threading;
-using MessageBox.Avalonia.DTO;
-using MessageBox.Avalonia.Enums;
 using MsBox.Avalonia.Base;
+using MsBox.Avalonia.Dto;
 using MsBox.Avalonia.Enums;
 using MsBox.Avalonia.ViewModels.Commands;
 

--- a/MsBox.Avalonia/Windows/MsBoxWindow.axaml.cs
+++ b/MsBox.Avalonia/Windows/MsBoxWindow.axaml.cs
@@ -1,8 +1,5 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
-using MsBox.Avalonia.Base;
 
 namespace MsBox.Avalonia.Windows;
 
@@ -13,11 +10,6 @@ public partial class MsBoxWindow : Window
         InitializeComponent();
         ShowInTaskbar = false;
         CanResize = false;
-    }
-
-    private void InitializeComponent()
-    {
-        AvaloniaXamlLoader.Load(this);
     }
     
     public async void CloseSafe()


### PR DESCRIPTION
- Fix binding parent for custom buttons: All buttons are disabled due to the binding fails.
- Namespace fixes
- Removed not needed XamlLoader