### PR TITLE
Updated dependencies

### DIFF
--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -27,8 +27,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.0.0" />
-        <PackageReference Include="DialogHost.Avalonia" Version="0.7.5" />
-        <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.0-d1" />
+        <PackageReference Include="DialogHost.Avalonia" Version="0.7.6" />
+        <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.1" />
     </ItemGroup>
     <ItemGroup>
       <None Update="icon.jpg">

--- a/XTest/XTest.Desktop/XTest.Desktop.csproj
+++ b/XTest/XTest.Desktop/XTest.Desktop.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="Avalonia.Desktop" Version="11.0.0" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-rc2.2" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/XTest/XTest/XTest.csproj
+++ b/XTest/XTest/XTest.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.0" />
         <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-rc2.2" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This updates the dependencies:
- DialogHost.Avalonia: 0.7.5 -> 0.7.6 (includes important bug fix https://github.com/AvaloniaUtils/DialogHost.Avalonia/issues/35)
- Markdown.Avalonia.Tight: 11.0.0-d1 -> 11.0.1 (update to latest stable version; 11.0.1 still target Avalonia 11.0.0)
- Avalonia.Diagnostics: 11.0.0-rc2.2 -> 11.0.0