### PR TITLE
Popup弹窗方式修改

### DIFF
--- a/Exmaple2.0/Exmaple2.0.csproj
+++ b/Exmaple2.0/Exmaple2.0.csproj
@@ -9,8 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Folder Include="Models\" />
         <AvaloniaResource Include="Assets\**" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <AvaloniaXaml Remove="Models\**" />
+      <Compile Remove="Models\**" />
+      <EmbeddedResource Remove="Models\**" />
+      <None Remove="Models\**" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Exmaple2.0/Views/MainWindow.axaml
+++ b/Exmaple2.0/Views/MainWindow.axaml
@@ -23,14 +23,17 @@
             <Setter Property="Height" Value="100" />
         </Style>
     </Window.Styles>
+  <ScrollViewer>
     <StackPanel>
-        <Button Name="Standard_Show"  Classes="View" Click="Standard_Show_OnClick" Content="Standard Show"/>
-        <Button Name="Standard_Dialog"  Classes="View" Click="Standard_Dialog_OnClick" Content="Standard Dialog"/>
-        <Button Name="Standard_Popup"  Classes="View" Click="Standard_Popup_OnClick" Content="Custom PopUp"/>
-        <Button Name="Custom_Show"  Classes="View" Click="Custom_Dialog_OnClick" Content="Custom Show"/>
-        <Button Name="Custom_MarkDown"  Classes="View"  Click="Custom_MarkDown_OnClick" Content="Custom Markdown"/>
-        <Button Name="Custom_Dialog"  Classes="View"  Click="Custom_Dialog_OnClick" Content="Custom dialog with image"/>
-        <Button Name="Custom_PopUp"  Classes="View" Click="Custom_PopUp_OnClick" Content="Custom popup"/>
-    </StackPanel>
+      <Button Name="Standard_Show"  Classes="View" Click="Standard_Show_OnClick" Content="Standard Show"/>
+      <Button Name="Standard_Dialog"  Classes="View" Click="Standard_Dialog_OnClick" Content="Standard Dialog"/>
+      <Button Name="Standard_Popup"  Classes="View" Click="Standard_Popup_OnClick" Content="Custom PopUp"/>
+      <Button Name="Custom_Show"  Classes="View" Click="Custom_Dialog_OnClick" Content="Custom Show"/>
+      <Button Name="Custom_MarkDown"  Classes="View"  Click="Custom_MarkDown_OnClick" Content="Custom Markdown"/>
+      <Button Name="Custom_Dialog"  Classes="View"  Click="Custom_Dialog_OnClick" Content="Custom dialog with image"/>
+      <Button Name="Custom_PopUp"  Classes="View" Click="Custom_PopUp_OnClick" Content="Custom popup"/>
 
+      <Button Name="Custom_CloseClickAway"  Classes="View" Click="Custom_CloseClickAway_OnClick" Content="Custom CloseClickAway"/>
+    </StackPanel>
+  </ScrollViewer>
 </Window>

--- a/Exmaple2.0/Views/MainWindow.axaml.cs
+++ b/Exmaple2.0/Views/MainWindow.axaml.cs
@@ -157,4 +157,43 @@ public partial class MainWindow : Window
     {
         throw new System.NotImplementedException();
     }
+
+    private async void Custom_CloseClickAway_OnClick(object sender, RoutedEventArgs e) {
+        var result =await MessageBoxManager.GetMessageBoxCustom(
+            new MessageBoxCustomParams {
+                ButtonDefinitions = new List<ButtonDefinition>{
+                    new ButtonDefinition { Name = "Yes", },
+                    new ButtonDefinition { Name = "No", },
+                    new ButtonDefinition { Name = "Cancel", }
+                },
+                ContentTitle = "title",
+                ContentMessage = "Informative note:" +
+                                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ut pulvinar est, eget porttitor magna. Maecenas nunc elit, pretium nec mauris vel, cursus faucibus leo. Mauris consequat magna vel mi malesuada semper. Donec nunc justo, rhoncus vel viverra a, ultrices vel nibh. Praesent ut libero a nunc placerat vulputate. Morbi ullamcorper pharetra lectus, ut lobortis ex consequat sit amet. Vestibulum pellentesque quam at justo hendrerit, et tincidunt nisl mattis. Curabitur eu nibh enim.\n",
+                Icon = MsBox.Avalonia.Enums.Icon.Question,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                CanResize = false,
+                MaxWidth = 500,
+                MaxHeight = 800,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                ShowInCenter = true,
+                Topmost = false,                
+            }).ShowAsPopupAsync(this);
+        await MessageBoxManager.GetMessageBoxCustom(
+            new MessageBoxCustomParams {
+                ButtonDefinitions = new List<ButtonDefinition>{
+                    new ButtonDefinition { Name = "OK", }
+                },
+                ContentTitle = "Result",
+                ContentMessage = "You Selected:"+ result,
+                Icon = MsBox.Avalonia.Enums.Icon.Question,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                CanResize = false,
+                MaxWidth = 500,
+                MaxHeight = 800,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                ShowInCenter = true,
+                Topmost = false,
+                CloseOnClickAway=true
+            }).ShowAsPopupAsync(this);
+    }
 }

--- a/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
+++ b/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
@@ -108,6 +108,11 @@ public abstract class AbstractMessageBoxParams
     /// Input
     /// </summary>
     public InputParams InputParams { get; set; }
+
+    /// <summary>
+    /// param to set closeOnClickAway
+    /// </summary>
+    public bool CloseOnClickAway { get; set; } = false;
 }
 
 public class HyperLinkParams

--- a/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
@@ -52,6 +52,7 @@ public abstract class AbstractMsBoxViewModel : INotifyPropertyChanged, IInput
         LocationOfMyWindow = @params.WindowStartupLocation;
         SystemDecorations = @params.SystemDecorations;
         Topmost = @params.Topmost;
+        CloseOnClickAway = @params.CloseOnClickAway;
 
         if (@params.HyperLinkParams != null)
         {
@@ -95,6 +96,7 @@ public abstract class AbstractMsBoxViewModel : INotifyPropertyChanged, IInput
     public WindowStartupLocation LocationOfMyWindow { get; }
 
     public event PropertyChangedEventHandler PropertyChanged;
+    public bool CloseOnClickAway { get; private set; }
 
     #region Hyperlink properties
     public abstract RelayCommand HyperLinkCommand { get; internal set; }


### PR DESCRIPTION
1：增加CloseClickAway参数，允许点击空白处关闭
1：Add the CloseClickAway parameter to allow clicking on the blank space to close it

2：连续多次调用弹窗时，会报错修复（原因是第一次返回时，窗口未关闭，修改为先关闭窗口，再返回）
2:  Fix Error When calling a popup 2 times, it's raiser error.  (the reason is that the window was not closed on the first return, so it was modified to close the window first and then return)