### PR TITLE
Custom Markdown example

### DIFF
--- a/Exmaple2.0/Exmaple2.0.csproj
+++ b/Exmaple2.0/Exmaple2.0.csproj
@@ -26,10 +26,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.1.3" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.1.3" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
+        <PackageReference Include="Avalonia" Version="11.1.5" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.1.5" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.5" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.1.5" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
     </ItemGroup>
 

--- a/Exmaple2.0/Views/MainWindow.axaml.cs
+++ b/Exmaple2.0/Views/MainWindow.axaml.cs
@@ -153,9 +153,97 @@ public partial class MainWindow : Window
         throw new NotImplementedException();
     }
 
-    private void Custom_MarkDown_OnClick(object sender, RoutedEventArgs e)
+    private async void Custom_MarkDown_OnClick(object sender, RoutedEventArgs e)
     {
-        throw new NotImplementedException();
+        const int maxWidth = 800;
+        const int maxHeight = 700;
+        var box = MessageBoxManager.GetMessageBoxCustom(
+            new MessageBoxCustomParams
+            {
+                ContentTitle = "title",
+                ContentMessage = """
+# h1 Heading
+## h2 Heading
+### h3 Heading
+#### h4 Heading
+##### h5 Heading
+###### h6 Heading
+
+## Emphasis
+**This is bold text**
+
+__This is underlined text__
+
+*This is italic text*
+
+~~Strikethrough~~
+
+## Blockquotes
+> Blockquotes can also be nested...
+>> ...by using additional greater-than signs right next to each other...
+> > > ...or with spaces between arrows.
+
+## Lists
+Unordered
++ Create a list by starting a line with `+`, `-`, or `*`
++ Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    * Ac tristique libero volutpat at
+    - Nulla volutpat aliquam velit
+
+Ordered
+1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+
+## Code
+
+Inline `code`
+
+Indented code
+
+    // Some comments
+    line 1 of code
+
+
+Block code "fences"
+
+```
+Sample text here...
+```
+
+Syntax highlighting
+```js
+var foo = function (bar) {
+  return bar++;
+};
+
+console.log(foo(5));
+```
+
+## Links
+[link text](https://example.com)
+
+## Images
+![Message](https://github.com/AvaloniaCommunity/MessageBox.Avalonia/raw/master/MsBox.Avalonia/icon.jpg)
+
+## Emojies
+:wink: :cry: :laughing: :yum:
+""",
+                Icon = MsBox.Avalonia.Enums.Icon.Info,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                CanResize = false,
+                MaxWidth = maxWidth,
+                MaxHeight = maxHeight,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                ShowInCenter = true,
+                Topmost = false,
+                Markdown = true,
+                ButtonDefinitions = [
+					new() {Name = "OK", IsDefault = true},
+				],
+            });
+
+        var result = await box.ShowAsync();
     }
 
     private async void Custom_CloseClickAway_OnClick(object sender, RoutedEventArgs e)

--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -28,7 +28,7 @@
         <AvaloniaResource Include="Assets\*" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.1.3" />
+        <PackageReference Include="Avalonia" Version="11.1.5" />
         <PackageReference Include="DialogHost.Avalonia" Version="0.8.1" />
     </ItemGroup>
     <ItemGroup>

--- a/XTest/XTest.Android/XTest.Android.csproj
+++ b/XTest/XTest.Android/XTest.Android.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Android" Version="11.1.3" />
+        <PackageReference Include="Avalonia.Android" Version="11.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/XTest/XTest.Browser/XTest.Browser.csproj
+++ b/XTest/XTest.Browser/XTest.Browser.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Browser" Version="11.1.3" />
+        <PackageReference Include="Avalonia.Browser" Version="11.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/XTest/XTest.Desktop/XTest.Desktop.csproj
+++ b/XTest/XTest.Desktop/XTest.Desktop.csproj
@@ -14,9 +14,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.1.5" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/XTest/XTest.iOS/XTest.iOS.csproj
+++ b/XTest/XTest.iOS/XTest.iOS.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.iOS" Version="11.1.3" />
+        <PackageReference Include="Avalonia.iOS" Version="11.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/XTest/XTest/XTest.csproj
+++ b/XTest/XTest/XTest.csproj
@@ -11,11 +11,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.1.3" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.3" />
+        <PackageReference Include="Avalonia" Version="11.1.5" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.5" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.5" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.5" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
     </ItemGroup>
 


### PR DESCRIPTION
- Bump Avalonia to 11.1.5
- Add Markdown example by implementing `Custom_MarkDown_OnClick` in example project
![obraz](https://github.com/user-attachments/assets/2bb4f824-787d-489d-9769-af9f3288a415)
