### PR TITLE
Password Input Support & enabled `ShowAsPopupAsync`

### DIFF
--- a/Exmaple2.0/Views/MainWindow.axaml
+++ b/Exmaple2.0/Views/MainWindow.axaml
@@ -29,6 +29,8 @@
       <Button Name="Standard_Context_Show"  Classes="View" Click="Standard_Context_Show_OnClick" Content="Standard Context Show"/>
       <Button Name="Standard_Dialog"  Classes="View" Click="Standard_Dialog_OnClick" Content="Standard Dialog"/>
       <Button Name="Standard_Popup"  Classes="View" Click="Standard_Popup_OnClick" Content="Custom PopUp"/>
+      <Button Name="StandardInput_PopUp" Classes="View" Click="StandardInput_PopUp_OnClick" Content="Standard input popup"/>
+      <Button Name="StandardInputPassword_PopUp" Classes="View" Click="StandardInputPassword_PopUp_OnClick" Content="Standard input password popup"/>
       <Button Name="Custom_Show"  Classes="View" Click="Custom_Dialog_OnClick" Content="Custom Show"/>
       <Button Name="Custom_MarkDown"  Classes="View"  Click="Custom_MarkDown_OnClick" Content="Custom Markdown"/>
       <Button Name="Custom_Dialog"  Classes="View"  Click="Custom_Dialog_OnClick" Content="Custom dialog with image"/>

--- a/Exmaple2.0/Views/MainWindow.axaml.cs
+++ b/Exmaple2.0/Views/MainWindow.axaml.cs
@@ -348,4 +348,49 @@ console.log(foo(5));
                 CloseOnClickAway = true
             }).ShowAsPopupAsync(this);
     }
+
+    private async void StandardInput_PopUp_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var msBox = MessageBoxManager.GetMessageBoxStandard(
+            new MessageBoxStandardParams
+            {
+                ContentTitle = "Input",
+                Icon = MsBox.Avalonia.Enums.Icon.Question,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                CanResize = false,
+                MaxWidth = 500,
+                MaxHeight = 800,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                ShowInCenter = true,
+                Topmost = false,
+                CloseOnClickAway = true,
+                InputParams = new InputParams { Label = "Your Name" }
+            });
+        await msBox.ShowAsPopupAsync(this);
+
+        Console.WriteLine("Your name is: " + msBox.InputValue);
+    }
+
+    private async void StandardInputPassword_PopUp_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var msBox = MessageBoxManager.GetMessageBoxStandard(
+            new MessageBoxStandardParams
+            {
+                ContentTitle = "Password Input",
+                Icon = MsBox.Avalonia.Enums.Icon.Question,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                CanResize = false,
+                MaxWidth = 500,
+                MaxHeight = 800,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                ShowInCenter = true,
+                Topmost = false,
+                CloseOnClickAway = true,
+                InputParams = new InputParams { Label = "Your Password", IsPassword = true, }
+            });
+
+        await msBox.ShowAsPopupAsync(this);
+
+        Console.WriteLine("Your password is: " + msBox.InputValue);
+    }
 }

--- a/MsBox.Avalonia/Base/IMsBox.cs
+++ b/MsBox.Avalonia/Base/IMsBox.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
 
+using DialogHostAvalonia;
+
 namespace MsBox.Avalonia.Base;
 
 public interface IMsBox<T>
@@ -32,6 +34,13 @@ public interface IMsBox<T>
     /// <param name="owner"></param>
     /// <returns></returns>
     Task<T> ShowAsPopupAsync(ContentControl owner);
+    
+    /// <summary>
+    ///  Show messagebox as popup
+    /// </summary>
+    /// <param name="owner"></param>
+    /// <returns></returns>
+    Task<T> ShowAsPopupAsync(DialogHost owner);
 
     /// <summary>
     /// Show messagebox as popup with owner

--- a/MsBox.Avalonia/Controls/MsBoxCustomView.axaml
+++ b/MsBox.Avalonia/Controls/MsBoxCustomView.axaml
@@ -107,8 +107,11 @@
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
           <TextBlock FontFamily="{Binding FontFamily}" IsVisible="{Binding IsInputVisible}" Text="{Binding InputLabel}" VerticalAlignment="Center" Margin="0,0,15,0" />
-          <TextBox Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding InputValue, Mode=TwoWay}" FontFamily="{Binding FontFamily}" IsVisible="{Binding IsInputVisible}"
-                   AcceptsReturn="{Binding IsInputMultiline}" />
+          <TextBox Grid.Column="1" Text="{Binding InputValue, Mode=TwoWay}" 
+                   FontFamily="{Binding FontFamily}" 
+                   IsVisible="{Binding IsInputVisible}"
+                   AcceptsReturn="{Binding IsInputMultiline}"
+                   PasswordChar="{Binding InputPasswordChar}" />
         </Grid>
         <!--Buttons-->
         <ItemsControl Name="ButtonItemsPresenter" Classes="buttons-item-presenter"

--- a/MsBox.Avalonia/Controls/MsBoxStandardView.axaml
+++ b/MsBox.Avalonia/Controls/MsBoxStandardView.axaml
@@ -10,7 +10,6 @@
              d:DataContext="{x:Static viewModels:DesignDataContexts.StandardInputViewModel}"
              x:Class="MsBox.Avalonia.Controls.MsBoxStandardView" MinWidth="{Binding MinWidth}"
              x:DataType="viewModels:MsBoxStandardViewModel"
-             xmlns:local="clr-namespace:MsBox.Avalonia"
              MaxWidth="{Binding MaxWidth}"
              Width="{Binding Width}"
              MinHeight="{Binding MinHeight}"
@@ -129,8 +128,11 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <TextBlock FontFamily="{Binding FontFamily}" IsVisible="{Binding IsInputVisible}" Text="{Binding InputLabel}" VerticalAlignment="Center" Margin="0,0,15,0" />
-            <TextBox Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding InputValue, Mode=TwoWay}" FontFamily="{Binding FontFamily}" IsVisible="{Binding IsInputVisible}"
-                     AcceptsReturn="{Binding IsInputMultiline}" />
+            <TextBox Grid.Column="1" Text="{Binding InputValue, Mode=TwoWay}" 
+                   FontFamily="{Binding FontFamily}" 
+                   IsVisible="{Binding IsInputVisible}"
+                   AcceptsReturn="{Binding IsInputMultiline}"
+                   PasswordChar="{Binding InputPasswordChar}" />
         </Grid>
         <!--Buttons-->
         <StackPanel Orientation="Horizontal" VerticalAlignment="Stretch"  Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"

--- a/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
+++ b/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
@@ -141,4 +141,8 @@ public class InputParams
     ///  Input multiline
     /// </summary>
     public bool Multiline { get; set; }
+    /// <summary>
+    /// Input is password
+    /// </summary>
+    public bool IsPassword { get; set; }
 }

--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.1.5" />
-        <PackageReference Include="DialogHost.Avalonia" Version="0.9.2" />
+        <PackageReference Include="DialogHost.Avalonia" Version="0.8.1" />
     </ItemGroup>
     <ItemGroup>
         <None Update="icon.jpg">

--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.1.5" />
-        <PackageReference Include="DialogHost.Avalonia" Version="0.8.1" />
+        <PackageReference Include="DialogHost.Avalonia" Version="0.9.2" />
     </ItemGroup>
     <ItemGroup>
         <None Update="icon.jpg">

--- a/MsBox.Avalonia/MsBox.cs
+++ b/MsBox.Avalonia/MsBox.cs
@@ -153,6 +153,38 @@ public class MsBox<V, VM, T> : IMsBox<T> where V : UserControl, IFullApi<T>, ISe
             {
                 owner.Styles.Remove(style);
             }
+
+            tcs.TrySetResult(r);
+        });
+        DialogHost.Show(_view, dh.Identifier);
+        return tcs.Task;
+    }
+
+    public Task<T> ShowAsPopupAsync(DialogHost dh)
+    {
+        _viewModel.SetFullApi(_view);
+
+        dh.CloseOnClickAway = false;
+        if (_viewModel is AbstractMsBoxViewModel abv) dh.CloseOnClickAway = abv.CloseOnClickAway;
+        dh.CloseOnClickAwayParameter = ClickAwayParam;
+        dh.DialogClosing += (ss, ee) =>
+        {
+            if (ee.Parameter?.ToString() == ClickAwayParam)
+            {
+                _view.Close();
+            }
+        };
+
+        var tcs = new TaskCompletionSource<T>();
+        _view.SetCloseAction(() =>
+        {
+            var r = _view.GetButtonResult();
+
+            if (dh.CurrentSession != null && dh.CurrentSession.IsEnded == false)
+            {
+                DialogHost.Close(dh.Identifier);
+            }
+
             tcs.TrySetResult(r);
         });
         DialogHost.Show(_view, dh.Identifier);

--- a/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
@@ -65,6 +65,7 @@ public abstract class AbstractMsBoxViewModel : INotifyPropertyChanged, IInput
             InputLabel = @params.InputParams.Label;
             InputValue = @params.InputParams.DefaultValue;
             IsInputMultiline = @params.InputParams.Multiline;
+            InputPasswordChar = @params.InputParams.IsPassword ? '*' : '\0';
             IsInputVisible = true;
         }
     }
@@ -98,19 +99,20 @@ public abstract class AbstractMsBoxViewModel : INotifyPropertyChanged, IInput
     public bool CloseOnClickAway { get; private set; }
 
     #region Hyperlink properties
-    public abstract RelayCommand HyperLinkCommand { get; internal set; }
-    public abstract string HyperLinkText { get; internal set; }
+    public abstract RelayCommand HyperLinkCommand { get; set; }
+    public abstract string HyperLinkText { get; set; }
 
-    public abstract bool IsHyperLinkVisible { get; internal set; }
+    public abstract bool IsHyperLinkVisible { get; set; }
 
     #endregion
 
     #region Input properties
 
-    public abstract string InputLabel { get; internal set; }
+    public abstract string InputLabel { get; set; }
     public abstract string InputValue { get; set; }
-    public abstract bool IsInputMultiline { get; internal set; }
-    public abstract bool IsInputVisible { get; internal set; }
+    public abstract bool IsInputMultiline { get; set; }
+    public abstract char InputPasswordChar { get; set; }
+    public abstract bool IsInputVisible { get; set; }
 
     #endregion
 

--- a/MsBox.Avalonia/ViewModels/MsBoxCustomViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/MsBoxCustomViewModel.cs
@@ -24,16 +24,17 @@ public class MsBoxCustomViewModel : AbstractMsBoxViewModel, ISetFullApi<string>
     public IEnumerable<ButtonDefinition> ButtonDefinitions { get; }
 
     #region Hyperlink properties
-    public override RelayCommand HyperLinkCommand { get; internal set; }
-    public override string HyperLinkText { get; internal set; }
-    public override bool IsHyperLinkVisible { get; internal set; }
+    public override RelayCommand HyperLinkCommand { get; set; }
+    public override string HyperLinkText { get; set; }
+    public override bool IsHyperLinkVisible { get; set; }
     #endregion
 
     #region Input properties
-    public override string InputLabel { get; internal set; }
+    public override string InputLabel { get; set; }
     public override string InputValue { get; set; }
-    public override bool IsInputMultiline { get; internal set; }
-    public override bool IsInputVisible { get; internal set; }
+    public override bool IsInputMultiline { get; set; }
+    public override char InputPasswordChar { get; set; }
+    public override bool IsInputVisible { get; set; }
     #endregion
 
     public RelayCommand ButtonClickCommand { get; }

--- a/MsBox.Avalonia/ViewModels/MsBoxStandardViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/MsBoxStandardViewModel.cs
@@ -44,19 +44,19 @@ public class MsBoxStandardViewModel : AbstractMsBoxViewModel, ISetFullApi<Button
     public bool IsCancelShowed { get; private set; }
 
     #region Hyperlink properties
-    public override RelayCommand HyperLinkCommand { get; internal set; }
-    public override string HyperLinkText { get; internal set; }
-    public override bool IsHyperLinkVisible { get; internal set; }
+    public override RelayCommand HyperLinkCommand { get; set; }
+    public override string HyperLinkText { get; set; }
+    public override bool IsHyperLinkVisible { get; set; }
     #endregion
 
     #region Input properties
-    public override string InputLabel { get; internal set; }
+    public override string InputLabel { get; set; }
     public override string InputValue { get; set; }
-    public override bool IsInputMultiline { get; internal set; }
-    public override bool IsInputVisible { get; internal set; }
+    public override bool IsInputMultiline { get; set; }
+    public override char InputPasswordChar { get; set; }
+    public override bool IsInputVisible { get; set; }
     public virtual object? Context { get; internal set; } = null;
     public virtual bool IsContextVisible { get; internal set; } = false;
-
     #endregion
 
     public RelayCommand ButtonClickCommand { get; }


### PR DESCRIPTION
### Summary
This PR introduces password input support for both standard and custom message boxes, adds a new `ShowAsPopupAsync` overload for `DialogHost`, and updates the example project to demonstrate these new features.

### Key Changes

- **Password Input Support**:
  - Added `IsPassword` property to `InputParams`.
  - Added `InputPasswordChar` property to `AbstractMsBoxViewModel` and its implementations (`MsBoxCustomViewModel`, `MsBoxStandardViewModel`).
  - Updated `MsBoxCustomView.axaml` and `MsBoxStandardView.axaml` to bind the `PasswordChar` property of the `TextBox` to `InputPasswordChar`.
  - When `IsPassword` is set to `true`, the message box will now display a password field (masked with `*` by default).

- **DialogHost Integration**:
  - Added a new overload for `ShowAsPopupAsync(DialogHost owner)` in `IMsBox` and `MsBox` class.

- **Example Project Updates**:
  - Added new buttons in `Exmaple2.0` to demonstrate:
    - Standard input popup.
    - Standard input password popup.
  - Implemented corresponding click handlers in `MainWindow.axaml.cs` using the new `ShowAsPopupAsync` functionality.

- **Refactoring**:
  - Changed several properties in `AbstractMsBoxViewModel` from `internal set` to `public set` (e.g., `InputLabel`, `IsInputMultiline`, `IsInputVisible`, `HyperLinkText`) to allow better accessibility and customization.

### How to test
1. Run the `Exmaple2.0` project.
2. Click on "Standard input popup" to see the basic input field in a popup.
3. Click on "Standard input password popup" to verify that the input is masked as a password.
4. Verify that the `DialogHost` integration works as expected when showing message boxes as popups.