### PR TITLE
Update to Avalonia 12.

### DIFF
--- a/Exmaple2.0/App.axaml
+++ b/Exmaple2.0/App.axaml
@@ -8,7 +8,7 @@
     </Application.DataTemplates>
 
     <Application.Styles>
-       <SimpleTheme></SimpleTheme>
+       <SimpleTheme />
         <StyleInclude Source="avares://MsBox.Avalonia.Markdown/Controls/MarkdownView.axaml" />
     </Application.Styles>
 

--- a/Exmaple2.0/App.axaml.cs
+++ b/Exmaple2.0/App.axaml.cs
@@ -12,6 +12,10 @@ public partial class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+//Uncomment these lines to use the new Dev Tools (part of Avalonia Plus or higher).
+//#if DEBUG
+     //   this.AttachDeveloperTools();
+//#endif
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/Exmaple2.0/Exmaple2.0.csproj
+++ b/Exmaple2.0/Exmaple2.0.csproj
@@ -29,6 +29,7 @@
         <PackageReference Include="Avalonia" Version="12.0.1" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+        <PackageReference Include="Avalonia.Themes.Simple" Version="12.0.1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     </ItemGroup>
 

--- a/Exmaple2.0/Exmaple2.0.csproj
+++ b/Exmaple2.0/Exmaple2.0.csproj
@@ -26,10 +26,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.0-rc2" />
+        <PackageReference Include="Avalonia" Version="12.0.0" />
         <PackageReference Include="Avalonia.Diagnostics" Version="11.3.13" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0-rc2" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.0.0-rc2" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     </ItemGroup>
 

--- a/Exmaple2.0/Exmaple2.0.csproj
+++ b/Exmaple2.0/Exmaple2.0.csproj
@@ -26,10 +26,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.0-rc1" />
+        <PackageReference Include="Avalonia" Version="12.0.0-rc2" />
         <PackageReference Include="Avalonia.Diagnostics" Version="11.3.13" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0-rc1" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.0.0-rc1" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0-rc2" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.0-rc2" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     </ItemGroup>
 

--- a/Exmaple2.0/Exmaple2.0.csproj
+++ b/Exmaple2.0/Exmaple2.0.csproj
@@ -27,7 +27,6 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.1" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.14" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />

--- a/Exmaple2.0/Exmaple2.0.csproj
+++ b/Exmaple2.0/Exmaple2.0.csproj
@@ -26,10 +26,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.13" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
+        <PackageReference Include="Avalonia" Version="12.0.1" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.14" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     </ItemGroup>
 

--- a/Exmaple2.0/Exmaple2.0.csproj
+++ b/Exmaple2.0/Exmaple2.0.csproj
@@ -26,11 +26,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.1.5" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.1.5" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.5" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.1.5" />
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
+        <PackageReference Include="Avalonia" Version="12.0.0-rc1" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.13" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0-rc1" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.0-rc1" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Exmaple2.0/Views/MainWindow.axaml.cs
+++ b/Exmaple2.0/Views/MainWindow.axaml.cs
@@ -24,10 +24,6 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-#if DEBUG
-        this.AttachDevTools();
-
-#endif
     }
 
     private async void Standard_Show_OnClick(object sender, RoutedEventArgs e)

--- a/MsBox.Avalonia.Markdown/MsBox.Avalonia.Markdown.csproj
+++ b/MsBox.Avalonia.Markdown/MsBox.Avalonia.Markdown.csproj
@@ -28,7 +28,7 @@
         <AvaloniaResource Include="Assets\*" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Markdown.Avalonia" Version="11.0.2" />
+        <PackageReference Include="Markdown.Avalonia" Version="12.0.0-a3" />
     </ItemGroup>
     <ItemGroup>
         <None Update="..\MsBox.Avalonia\icon.jpg">

--- a/MsBox.Avalonia.Markdown/MsBox.Avalonia.Markdown.csproj
+++ b/MsBox.Avalonia.Markdown/MsBox.Avalonia.Markdown.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <PackageVersion>3.2.0.0</PackageVersion>
+        <PackageVersion>4.0.0.0</PackageVersion>
         <Title>MessageBox.Avalonia.Markdown</Title>
         <Authors>Lary</Authors>
         <Description>Mardkown support for Messagebox AvaloniaUI</Description>
@@ -10,7 +10,7 @@
         <RepositoryUrl>messagebox.avalonia</RepositoryUrl>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageTags>Avalonia MessageBox Markdown</PackageTags>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/MsBox.Avalonia/Controls/MsBoxCustomView.axaml.cs
+++ b/MsBox.Avalonia/Controls/MsBoxCustomView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
 
@@ -46,12 +47,12 @@ public partial class MsBoxCustomView : UserControl, IFullApi<string>, ISetCloseA
     public Task Copy()
     {
         var clipboard = TopLevel.GetTopLevel(this).Clipboard;
-        DataTransfer copier = new();
-        if (string.IsNullOrEmpty(ContentTextBox.SelectedText))
+        var text = ContentTextBox.SelectedText;
+        if (string.IsNullOrEmpty(text))
         {
-            copier.Add(DataTransferItem.CreateText(ContentTextBox.SelectedText));
+            text = (DataContext as AbstractMsBoxViewModel)?.ContentMessage;
         }
-        return clipboard?.SetDataAsync(copier);
+        return ClipboardExtensions.SetTextAsync(clipboard, text);
     }
 
     public void Close()

--- a/MsBox.Avalonia/Controls/MsBoxCustomView.axaml.cs
+++ b/MsBox.Avalonia/Controls/MsBoxCustomView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
 
@@ -45,12 +46,12 @@ public partial class MsBoxCustomView : UserControl, IFullApi<string>, ISetCloseA
     public Task Copy()
     {
         var clipboard = TopLevel.GetTopLevel(this).Clipboard;
-        var text = ContentTextBox.SelectedText;
-        if (string.IsNullOrEmpty(text))
+        DataTransfer copier = new();
+        if (string.IsNullOrEmpty(ContentTextBox.SelectedText))
         {
-            text = (DataContext as AbstractMsBoxViewModel)?.ContentMessage;
+            copier.Add(DataTransferItem.CreateText(ContentTextBox.SelectedText));
         }
-        return clipboard?.SetTextAsync(text);
+        return clipboard?.SetDataAsync(copier);
     }
 
     public void Close()

--- a/MsBox.Avalonia/Controls/MsBoxCustomView.axaml.cs
+++ b/MsBox.Avalonia/Controls/MsBoxCustomView.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;

--- a/MsBox.Avalonia/Controls/MsBoxStandardView.axaml.cs
+++ b/MsBox.Avalonia/Controls/MsBoxStandardView.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
+using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
 
@@ -57,12 +58,12 @@ public partial class MsBoxStandardView : UserControl, IFullApi<ButtonResult>, IS
     public Task Copy()
     {
         var clipboard = TopLevel.GetTopLevel(this).Clipboard;
-        var text = ContentTextBox.SelectedText;
-        if (string.IsNullOrEmpty(text))
+        DataTransfer copier = new();
+        if (string.IsNullOrEmpty(ContentTextBox.SelectedText))
         {
-            text = (DataContext as AbstractMsBoxViewModel)?.ContentMessage;
+            copier.Add(DataTransferItem.CreateText(ContentTextBox.SelectedText));
         }
-        return clipboard?.SetTextAsync(text);
+        return clipboard?.SetDataAsync(copier);
     }
 
     public void Close()

--- a/MsBox.Avalonia/Controls/MsBoxStandardView.axaml.cs
+++ b/MsBox.Avalonia/Controls/MsBoxStandardView.axaml.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
-using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;

--- a/MsBox.Avalonia/Controls/MsBoxStandardView.axaml.cs
+++ b/MsBox.Avalonia/Controls/MsBoxStandardView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
 
@@ -58,12 +59,12 @@ public partial class MsBoxStandardView : UserControl, IFullApi<ButtonResult>, IS
     public Task Copy()
     {
         var clipboard = TopLevel.GetTopLevel(this).Clipboard;
-        DataTransfer copier = new();
-        if (string.IsNullOrEmpty(ContentTextBox.SelectedText))
+        var text = ContentTextBox.SelectedText;
+        if (string.IsNullOrEmpty(text))
         {
-            copier.Add(DataTransferItem.CreateText(ContentTextBox.SelectedText));
+            text = (DataContext as AbstractMsBoxViewModel)?.ContentMessage;
         }
-        return clipboard?.SetDataAsync(copier);
+        return ClipboardExtensions.SetTextAsync(clipboard, text);
     }
 
     public void Close()

--- a/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
+++ b/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
@@ -91,7 +91,7 @@ public abstract class AbstractMessageBoxParams
     /// <summary>
     /// Determines system decorations (title bar, border, etc)
     /// </summary>
-    public WindowDecorations SystemDecorations { get; set; } = WindowDecorations.Full;
+    public WindowDecorations WindowDecorations { get; set; } = WindowDecorations.Full;
 
     /// <summary>
     /// Window under all windows

--- a/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
+++ b/MsBox.Avalonia/Dto/AbstractMessageBoxParams.cs
@@ -91,7 +91,7 @@ public abstract class AbstractMessageBoxParams
     /// <summary>
     /// Determines system decorations (title bar, border, etc)
     /// </summary>
-    public SystemDecorations SystemDecorations { get; set; } = SystemDecorations.Full;
+    public WindowDecorations SystemDecorations { get; set; } = WindowDecorations.Full;
 
     /// <summary>
     /// Window under all windows

--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -28,7 +28,7 @@
         <AvaloniaResource Include="Assets\*" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.0-rc1" />
+        <PackageReference Include="Avalonia" Version="12.0.0-rc2" />
         <PackageReference Include="DialogHost.Avalonia" Version="0.11.0" />
     </ItemGroup>
     <ItemGroup>

--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -28,8 +28,8 @@
         <AvaloniaResource Include="Assets\*" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.0" />
-        <PackageReference Include="DialogHost.Avalonia" Version="0.11.1" />
+        <PackageReference Include="Avalonia" Version="12.0.1" />
+        <PackageReference Include="DialogHost.Avalonia" Version="0.12.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="icon.jpg">

--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <PackageVersion>3.3.1.1</PackageVersion>
+        <PackageVersion>4.0.0.0</PackageVersion>
         <Title>MessageBox.Avalonia</Title>
         <Authors>Lary</Authors>
         <Description>Messagebox for AvaloniaUI</Description>
@@ -10,7 +10,7 @@
         <RepositoryUrl>messagebox.avalonia</RepositoryUrl>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageTags>Avalonia MessageBox</PackageTags>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -28,8 +28,8 @@
         <AvaloniaResource Include="Assets\*" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.1.5" />
-        <PackageReference Include="DialogHost.Avalonia" Version="0.8.1" />
+        <PackageReference Include="Avalonia" Version="12.0.0-rc1" />
+        <PackageReference Include="DialogHost.Avalonia" Version="0.11.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="icon.jpg">

--- a/MsBox.Avalonia/MsBox.Avalonia.csproj
+++ b/MsBox.Avalonia/MsBox.Avalonia.csproj
@@ -28,8 +28,8 @@
         <AvaloniaResource Include="Assets\*" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.0-rc2" />
-        <PackageReference Include="DialogHost.Avalonia" Version="0.11.0" />
+        <PackageReference Include="Avalonia" Version="12.0.0" />
+        <PackageReference Include="DialogHost.Avalonia" Version="0.11.1" />
     </ItemGroup>
     <ItemGroup>
         <None Update="icon.jpg">

--- a/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
@@ -49,7 +49,7 @@ public abstract class AbstractMsBoxViewModel : INotifyPropertyChanged, IInput
         WindowIconPath = @params.WindowIcon;
         SizeToContent = @params.SizeToContent;
         LocationOfMyWindow = @params.WindowStartupLocation;
-        SystemDecorations = @params.SystemDecorations;
+        WindowDecorations = @params.WindowDecorations;
         Topmost = @params.Topmost;
         CloseOnClickAway = @params.CloseOnClickAway;
 
@@ -87,7 +87,7 @@ public abstract class AbstractMsBoxViewModel : INotifyPropertyChanged, IInput
     public double MaxHeight { get; set; }
     public double Height { get; set; }
 
-    public WindowDecorations SystemDecorations { get; set; }
+    public WindowDecorations WindowDecorations { get; set; }
     public bool Topmost { get; set; }
 
     public SizeToContent SizeToContent { get; set; } = SizeToContent.Height;

--- a/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
+++ b/MsBox.Avalonia/ViewModels/AbstractMsBoxViewModel.cs
@@ -87,7 +87,7 @@ public abstract class AbstractMsBoxViewModel : INotifyPropertyChanged, IInput
     public double MaxHeight { get; set; }
     public double Height { get; set; }
 
-    public SystemDecorations SystemDecorations { get; set; }
+    public WindowDecorations SystemDecorations { get; set; }
     public bool Topmost { get; set; }
 
     public SizeToContent SizeToContent { get; set; } = SizeToContent.Height;

--- a/MsBox.Avalonia/Windows/MsBoxWindow.axaml
+++ b/MsBox.Avalonia/Windows/MsBoxWindow.axaml
@@ -7,7 +7,7 @@
         x:Class="MsBox.Avalonia.Windows.MsBoxWindow"
         SizeToContent="WidthAndHeight"
         x:DataType="viewModels:AbstractMsBoxViewModel"
-        SystemDecorations="{Binding SystemDecorations}"
+        WindowDecorations="{Binding SystemDecorations}"
         Topmost="{Binding Topmost}"
         Icon="{Binding WindowIconPath}"
         WindowStartupLocation="{Binding LocationOfMyWindow}"

--- a/MsBox.Avalonia/Windows/MsBoxWindow.axaml
+++ b/MsBox.Avalonia/Windows/MsBoxWindow.axaml
@@ -7,7 +7,7 @@
         x:Class="MsBox.Avalonia.Windows.MsBoxWindow"
         SizeToContent="WidthAndHeight"
         x:DataType="viewModels:AbstractMsBoxViewModel"
-        WindowDecorations="{Binding SystemDecorations}"
+        WindowDecorations="{Binding WindowDecorations}"
         Topmost="{Binding Topmost}"
         Icon="{Binding WindowIconPath}"
         WindowStartupLocation="{Binding LocationOfMyWindow}"


### PR DESCRIPTION
Fixes #220 .
Since Avalonia 12 has breaking changes (including dropping support for .NET Standard 2.0), I've changed the version numbers to 4.0 as well.